### PR TITLE
Remove redundant default_max_x/y config values in favour of max_x/y

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -17,7 +17,7 @@ ImageOptimiserService:
   enabledCommands:
   binDirectory: '/usr/local/bin'
   optimisingQuality: 80
-  
+
 OptimisedGDBackend:
   dependencies:
     OptimiserService: '%$ImageOptimiserService'
@@ -29,5 +29,5 @@ OptimisedImagickBackend:
 Name: 'resample'
 ---
 ResampleImage:
-  default_max_x: 1024
-  default_max_y: 1024
+  max_x: 1024
+  max_y: 1024

--- a/code/ResampleImage.php
+++ b/code/ResampleImage.php
@@ -27,7 +27,7 @@ class ResampleImage extends DataExtension
      */
     public function getMaxX()
     {
-        return (int) $this->config->get('max_x') ?: $this->config->get('default_max_x');
+        return (int) $this->config->get('max_x');
     }
 
     /**
@@ -37,7 +37,7 @@ class ResampleImage extends DataExtension
      */
     public function getMaxY()
     {
-        return (int) $this->config->get('max_y') ?: $this->config->get('default_max_y');
+        return (int) $this->config->get('max_y');
     }
 
     /**


### PR DESCRIPTION
The config system allows users to override module config values in their own configs. The default values can be set using the same config value as the user will override. This is a non-breaking change (except for anyone using the `default_max_x/y` values in their config).

@clairefinnie - can you merge this one?