### PR TITLE
Update dependencies to support Symfony Process 2.x and 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
 		}
 	],
 	"require": {
-		"composer/installers": "~1.0",
-		"symfony/process": "~2.3"
+		"composer/installers": "^1.0",
+		"symfony/process": "^2.3|^3.0"
 	},
 	"supports": {
 		"raven/raven": "Allows logging for image optimisation through raven and sentry"


### PR DESCRIPTION
The changelog for 3.x doesn't indicate any incompatibility. Tested and works as expected.

Closes #16 